### PR TITLE
Minor adjustments

### DIFF
--- a/kexec/autojustdoit.nix
+++ b/kexec/autojustdoit.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+{
+  options = {
+    kexec.autoJustdoit = lib.mkOption {
+      default = true;
+      description = "automatically run justdoit on boot";
+      type = lib.types.bool;
+    };
+  };
+  config = lib.mkIf config.kexec.autoJustdoit {
+    systemd.units.justdoit = {
+      wantedBy = [ "multi-user.target" ];
+    };
+    systemd.services.justdoit = {
+      script = "${config.system.build.justdoit}/justdoit";
+    };
+  };
+}

--- a/kexec/configuration.nix
+++ b/kexec/configuration.nix
@@ -5,7 +5,7 @@
 with lib;
 
 {
-  imports = [ <nixpkgs/nixos/modules/installer/netboot/netboot-minimal.nix> ./autoreboot.nix ./kexec.nix ./justdoit.nix ];
+  imports = [ <nixpkgs/nixos/modules/installer/netboot/netboot-minimal.nix> ./autoreboot.nix ./autojustdoit.nix ./kexec.nix ./justdoit.nix ];
 
   nixpkgs.localSystem.system = "x86_64-linux";
   boot.supportedFilesystems = [ "zfs" ];

--- a/kexec/configuration.nix
+++ b/kexec/configuration.nix
@@ -7,6 +7,7 @@ with lib;
 {
   imports = [ <nixpkgs/nixos/modules/installer/netboot/netboot-minimal.nix> ./autoreboot.nix ./kexec.nix ./justdoit.nix ];
 
+  nixpkgs.localSystem.system = "x86_64-linux";
   boot.supportedFilesystems = [ "zfs" ];
   boot.loader.grub.enable = false;
   boot.kernelParams = [

--- a/kexec/justdoit.nix
+++ b/kexec/justdoit.nix
@@ -48,6 +48,8 @@ in {
     system.build.justdoit = pkgs.writeScriptBin "justdoit" ''
       #!${pkgs.stdenv.shell}
 
+      SSH_KEY=$(cat /root/.ssh/authorized_keys)
+
       set -e
 
       vgchange -a n
@@ -124,10 +126,16 @@ in {
           { name = "root"; device = "${cfg.rootDevice}${x}2"; preLVM = true; }
         ];
       ''}
+        users.users.root.openssh.authorizedKeys.keys = [
+          "$SSH_KEY"
+        ];
       }
       EOF
 
-      nixos-install
+      echo ">>> your generated nix config is:"
+      cat /mnt/etc/nixos/generated.nix
+
+      nixos-install --no-root-passwd
 
       umount /mnt/home /mnt/nix /mnt/boot /mnt
       zpool export ${cfg.poolName}

--- a/kexec/target-config.nix
+++ b/kexec/target-config.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [ ./hardware-configuration.nix ./generated.nix ];
+  nixpkgs.localSystem.system = "x86_64-linux";
   boot.loader.grub.enable = true;
   boot.loader.grub.version = 2;
   services.openssh.enable = true;


### PR DESCRIPTION
I also have the following `user-data.yaml`

```
#cloud-config
write_files:
  - path: /root/install-nix.sh
    content: |
        #!/bin/bash
        set -x
        set -e
        export USER=$(whoami)
        export HOME=/root
        wget http://zw3rk-pub-bucket.s3.amazonaws.com/nixos-system-x86_64-linux.tar.xz
        tar -xf nixos-system-x86_64-linux.tar.xz
        cp /root/.ssh/authorized_keys /ssh_pubkey
        ./kexec_nixos

runcmd:
  - bash -l /root/install-nix.sh
```

though I'd prefer not to have to host the `.tar.xz` at 400mb myself :-)