### PR TITLE
Disable autoreboot by default

### DIFF
--- a/kexec/autoreboot.nix
+++ b/kexec/autoreboot.nix
@@ -3,7 +3,7 @@
 {
   options = {
     kexec.autoReboot = lib.mkOption {
-      default = true;
+      default = false;
       description = "auto-reboot at the end of the hour";
       type = lib.types.bool;
     };


### PR DESCRIPTION
This has killed at least 2 VMs by shutting them down in the middle of a repartitioning. I don't really see a reason why `nixos-generate -f kexec` should *enable* this strange feature by default, and it doesn't seem documented either, so I propose turning it off by default.