### PR TITLE
kexec image: fix cross compile

### DIFF
--- a/kexec/kexec.nix
+++ b/kexec/kexec.nix
@@ -2,7 +2,7 @@
 
 {
   system.build = rec {
-    image = pkgs.runCommand "image" { buildInputs = [ pkgs.nukeReferences ]; } ''
+    image = pkgs.runCommand "image" { nativeBuildInputs = [ pkgs.nukeReferences ]; } ''
       mkdir $out
       cp ${config.system.build.kernel}/${config.system.boot.loader.kernelFile} $out/kernel
       cp ${config.system.build.netbootRamdisk}/initrd $out/initrd


### PR DESCRIPTION
nuke-refs is a *native* build dependency. This isn't enough to enable cross-compiling with the default configuration.nix, but after this patch I've successfully built an Aarch64 image on x86-64 for a stripped-down configuration.nix.