### PR TITLE
justdoit: some bug fixes

### DIFF
--- a/kexec/justdoit.nix
+++ b/kexec/justdoit.nix
@@ -19,7 +19,7 @@ in {
       };
       bootType = mkOption {
         type = types.enum [ "ext4" "vfat" "zfs" ];
-        default = "ext4";
+        default = if cfg.uefi then "vfat" else "ext4";
       };
       swapSize = mkOption {
         type = types.int;

--- a/kexec/justdoit.nix
+++ b/kexec/justdoit.nix
@@ -92,7 +92,7 @@ in {
 
       ${mkBootTable.${cfg.bootType}}
       mkswap $SWAP_DEVICE -L NIXOS_SWAP
-      zpool create -o ashift=12 -o altroot=/mnt ${cfg.poolName} $ROOT_DEVICE
+      zpool create -f -o ashift=12 -o altroot=/mnt ${cfg.poolName} $ROOT_DEVICE
       zfs create -o mountpoint=legacy ${cfg.poolName}/root
       zfs create -o mountpoint=legacy ${cfg.poolName}/home
       zfs create -o mountpoint=legacy ${cfg.poolName}/nix


### PR DESCRIPTION
- justdoit: set bootType to vfat if uefi is true

  Without this, ext4 would always be used, even if uefi is true, which is incorrect

- justdoit: set -f on zpool create

  This fixes the case where justdoit has previously been used on a disk before, where /dev/sda3 may contain an existing ZFS member signature/label for example. This would usually have to be cleared by zpool clearlabel, but passing -f to zpool create also works

  ```
  > + zpool create -o ashift=12 -o altroot=/mnt tank /dev/sda3
  > invalid vdev specification
  > use '-f' to override the following errors:
  > /dev/sda3 is part of potentially active pool 'tank'
  ```